### PR TITLE
Fix AccordionProps typo

### DIFF
--- a/components/utils/accordion.tsx
+++ b/components/utils/accordion.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 
-type AccordionpProps = {
+type AccordionProps = {
   children: React.ReactNode
   tag?: string
   title: string
@@ -14,7 +14,7 @@ export default function Accordion({
   tag = 'li',
   title,
   active = false
-}: AccordionpProps) {
+}: AccordionProps) {
 
   const [accordionOpen, setAccordionOpen] = useState<boolean>(false)
   const accordion = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- correct a typo in `AccordionProps`
- update component signature accordingly

## Testing
- `npx tsc`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68508a13dae8832d88b5cb755e2d7fe8