### PR TITLE
Fix missing effect dependencies

### DIFF
--- a/app/(default)/layout.tsx
+++ b/app/(default)/layout.tsx
@@ -20,7 +20,7 @@ export default function DefaultLayout({
       duration: 700,
       easing: 'ease-out-cubic',
     })
-  })
+  }, [])
 
   return (
     <>

--- a/app/race-results/layout.tsx
+++ b/app/race-results/layout.tsx
@@ -20,7 +20,7 @@ export default function DefaultLayout({
       duration: 700,
       easing: 'ease-out-cubic',
     })
-  })
+  }, [])
 
   return (
     <>

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
     scrollHandler()
     window.addEventListener('scroll', scrollHandler)
     return () => window.removeEventListener('scroll', scrollHandler)
-  }, [top])
+  }, [])
 
   return (
     <header className={`fixed w-full z-30 md:bg-opacity-90 transition duration-300 ease-in-out ${!top ? 'bg-white backdrop-blur-sm shadow-lg' : ''}`}>

--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -13,23 +13,23 @@ export default function MobileMenu() {
   // close the mobile menu on click outside
   useEffect(() => {
     const clickHandler = ({ target }: { target: EventTarget | null }): void => {
-      if (!mobileNav.current || !trigger.current) return;
-      if (!mobileNavOpen || mobileNav.current.contains(target as Node) || trigger.current.contains(target as Node)) return;
+      if (!mobileNav.current || !trigger.current) return
+      if (!mobileNavOpen || mobileNav.current.contains(target as Node) || trigger.current.contains(target as Node)) return
       setMobileNavOpen(false)
-    };
+    }
     document.addEventListener('click', clickHandler)
     return () => document.removeEventListener('click', clickHandler)
-  })
+  }, [])
 
   // close the mobile menu if the esc key is pressed
   useEffect(() => {
     const keyHandler = ({ keyCode }: { keyCode: number }): void => {
-      if (!mobileNavOpen || keyCode !== 27) return;
+      if (!mobileNavOpen || keyCode !== 27) return
       setMobileNavOpen(false)
-    };
+    }
     document.addEventListener('keydown', keyHandler)
     return () => document.removeEventListener('keydown', keyHandler)
-  })
+  }, [])
 
   return (
     <div className="flex hidden">

--- a/components/utils/accordion.tsx
+++ b/components/utils/accordion.tsx
@@ -22,7 +22,7 @@ export default function Accordion({
 
   useEffect(() => {
     setAccordionOpen(active)
-  }, [accordion])
+  }, [active])
 
   return (
     <Component>


### PR DESCRIPTION
## Summary
- correct Accordion useEffect to watch `active` prop
- prevent duplicate AOS initialization
- avoid duplicate scroll handler setup
- prevent multiple mobile menu event listeners

## Testing
- `npm ci`
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_685088b8dedc832db5266a6570d572bd