### PR TITLE
Improve homepage with league details

### DIFF
--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -1,6 +1,6 @@
 export const metadata = {
   title: 'Home - SLF1',
-  description: 'Page description',
+  description: 'Sunday League F1 25 – weekly online racing and a welcoming community',
 }
 
 import Hero from '@/components/hero'

--- a/components/features-blocks.tsx
+++ b/components/features-blocks.tsx
@@ -11,8 +11,8 @@ export default function FeaturesBlocks() {
 
           {/* Section header */}
           <div className="max-w-3xl mx-auto text-center pb-12 md:pb-20">
-            <h2 className="h2 mb-4">Explore the solutions</h2>
-            <p className="text-xl text-gray-600">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat cupidatat.</p>
+            <h2 className="h2 mb-4">Why Join Sunday League?</h2>
+            <p className="text-xl text-gray-600">Competitive racing, great people and plenty of fun &mdash; here&rsquo;s what you can expect.</p>
           </div>
 
           {/* Items */}
@@ -31,8 +31,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Weekly Races</h4>
+              <p className="text-gray-600 text-center">Race every Sunday with up to 18 drivers on the grid.</p>
             </div>
 
             {/* 2nd item */}
@@ -47,8 +47,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Friendly Community</h4>
+              <p className="text-gray-600 text-center">Meet racers from around the world and enjoy clean competition.</p>
             </div>
 
             {/* 3rd item */}
@@ -64,8 +64,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Social Events</h4>
+              <p className="text-gray-600 text-center">Join open lobby sessions for extra wheel-to-wheel action.</p>
             </div>
 
             {/* 4th item */}
@@ -81,8 +81,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Roles For Everyone</h4>
+              <p className="text-gray-600 text-center">Drivers, reserves, commentators and FIA members all welcome.</p>
             </div>
 
             {/* 5th item */}
@@ -97,8 +97,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Realistic Settings</h4>
+              <p className="text-gray-600 text-center">50% distance, dynamic weather and standard damage with equal cars.</p>
             </div>
 
             {/* 6th item */}
@@ -112,8 +112,8 @@ export default function FeaturesBlocks() {
                   </g>
                 </g>
               </svg>
-              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Headless CMS</h4>
-              <p className="text-gray-600 text-center">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+              <h4 className="text-xl font-bold leading-snug tracking-tight mb-1">Race Times</h4>
+              <p className="text-gray-600 text-center">Sundays at 7&nbsp;PM UK / 8&nbsp;PM CET &mdash; subject to the F1 calendar.</p>
             </div>
 
           </div>

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -32,7 +32,7 @@ export default function Features() {
 
           {/* Section header */}
           <div className="max-w-3xl mx-auto text-center pb-12 md:pb-16">
-            <h1 className="h2 mb-4">Explore Sunday League!</h1>
+            <h1 className="h2 mb-4">League Highlights</h1>
         
           </div>
 
@@ -42,8 +42,8 @@ export default function Features() {
             {/* Content */}
             <div className="max-w-xl md:max-w-none md:w-full mx-auto md:col-span-7 lg:col-span-6 md:mt-6" data-aos="fade-right">
               <div className="md:pr-4 lg:pr-12 xl:pr-16 mb-8">
-                <h3 className="h3 mb-3">Powerful suite of tools</h3>
-                <p className="text-xl text-gray-600">Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa.</p>
+                <h3 className="h3 mb-3">Built for Racers</h3>
+                <p className="text-xl text-gray-600">Sunday League F1&nbsp;25 delivers serious competition while keeping things fun and accessible for all skill levels.</p>
               </div>
               {/* Tabs buttons */}
               <div className="mb-8 md:mb-0">
@@ -53,8 +53,8 @@ export default function Features() {
                   onClick={(e) => { e.preventDefault(); setTab(1); }}
                 >
                   <div>
-                    <div className="font-bold leading-snug tracking-tight mb-1">Building the Simple ecosystem</div>
-                    <div className="text-gray-600">Take collaboration to the next level with security and administrative features built for teams.</div>
+                    <div className="font-bold leading-snug tracking-tight mb-1">Competitive Environment</div>
+                    <div className="text-gray-600">Short qualifying sessions followed by 50% races with equal car performance.</div>
                   </div>
                   <div className="flex justify-center items-center w-8 h-8 bg-white rounded-full shadow flex-shrink-0 ml-3">
                     <svg className="w-3 h-3 fill-current" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
@@ -68,8 +68,8 @@ export default function Features() {
                   onClick={(e) => { e.preventDefault(); setTab(2); }}
                 >
                   <div>
-                    <div className="font-bold leading-snug tracking-tight mb-1">Building the Simple ecosystem</div>
-                    <div className="text-gray-600">Take collaboration to the next level with security and administrative features built for teams.</div>
+                    <div className="font-bold leading-snug tracking-tight mb-1">Community Focus</div>
+                    <div className="text-gray-600">Regular social races and events keep things lively between league rounds.</div>
                   </div>
                   <div className="flex justify-center items-center w-8 h-8 bg-white rounded-full shadow flex-shrink-0 ml-3">
                     <svg className="w-3 h-3 fill-current" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">
@@ -83,8 +83,8 @@ export default function Features() {
                   onClick={(e) => { e.preventDefault(); setTab(3); }}
                 >
                   <div>
-                    <div className="font-bold leading-snug tracking-tight mb-1">Building the Simple ecosystem</div>
-                    <div className="text-gray-600">Take collaboration to the next level with security and administrative features built for teams.</div>
+                    <div className="font-bold leading-snug tracking-tight mb-1">Fair Racing</div>
+                    <div className="text-gray-600">Strict corner cutting and sensible damage settings ensure clean fights on track.</div>
                   </div>
                   <div className="flex justify-center items-center w-8 h-8 bg-white rounded-full shadow flex-shrink-0 ml-3">
                     <svg className="w-3 h-3 fill-current" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -30,15 +30,15 @@ export default function Hero() {
 
           {/* Section header */}
           <div className="text-center pb-12 md:pb-16">
-            <h1 className="text-5xl md:text-6xl font-extrabold leading-tighter tracking-tighter mb-4" data-aos="zoom-y-out">Sunday League <span className="bg-clip-text text-transparent bg-gradient-to-r from-black to-red-600">F1 WIP</span></h1>
+            <h1 className="text-5xl md:text-6xl font-extrabold leading-tighter tracking-tighter mb-4" data-aos="zoom-y-out">Sunday League <span className="bg-clip-text text-transparent bg-gradient-to-r from-black to-red-600">F1&nbsp;25</span></h1>
             <div className="max-w-3xl mx-auto">
-              <p className="text-xl text-gray-600 mb-8" data-aos="zoom-y-out" data-aos-delay="150">Sunday League is an F1 23 Racing League, Join our discord today!</p>
+              <p className="text-xl text-gray-600 mb-8" data-aos="zoom-y-out" data-aos-delay="150">A worldwide F1&nbsp;25 league with weekly races and a thriving community. Seats are limited &mdash; join our Discord today!</p>
               <div className="max-w-xs mx-auto sm:max-w-none sm:flex sm:justify-center" data-aos="zoom-y-out" data-aos-delay="300">
                 <div className="btn text-white bg-red-600 hover:bg-red-800 w-full mb-4 sm:w-auto sm:mb-0">
                 <Link href="/race-results" className="text-white hover:underline transition duration-150 ease-in-out">Race Results</Link>
                 </div>
                 <div>
-                  <a className="btn text-white bg-discord hover:bg-gray-800 w-full sm:w-auto sm:ml-4" href="https://discord.gg/W3PMnmrqVd" target='_blank'>Discord</a>
+                  <a className="btn text-white bg-discord hover:bg-gray-800 w-full sm:w-auto sm:ml-4" href="https://discord.gg/EqrUdXfbHU" target='_blank'>Discord</a>
                 </div>
               </div>
             </div>

--- a/components/newsletter.tsx
+++ b/components/newsletter.tsx
@@ -37,19 +37,12 @@ export default function Newsletter() {
 
               {/* CTA content */}
               <div className="text-center lg:text-left lg:max-w-xl">
-                <h3 className="h3 text-white mb-2">Want more tutorials & guides?</h3>
-                <p className="text-gray-300 text-lg mb-6">Lorem ipsum dolor sit amet consectetur adipisicing elit nemo expedita voluptas culpa sapiente.</p>
+                <h3 className="h3 text-white mb-2">Join Sunday League F1&nbsp;25</h3>
+                <p className="text-gray-300 text-lg mb-6">Seats are first come, first served. Click below to join our Discord and secure yours.</p>
 
-                {/* CTA form */}
-                <form className="w-full lg:w-auto">
-                  <div className="flex flex-col sm:flex-row justify-center max-w-xs mx-auto sm:max-w-md lg:mx-0">
-                    <input type="email" className="form-input w-full appearance-none bg-gray-800 border border-gray-700 focus:border-gray-600 rounded-sm px-4 py-3 mb-2 sm:mb-0 sm:mr-2 text-white placeholder-gray-500" placeholder="Your email…" aria-label="Your email…" />
-                    <a className="btn text-white bg-blue-600 hover:bg-blue-700 shadow" href="#0">Subscribe</a>
-                  </div>
-                  {/* Success message */}
-                  {/* <p className="text-sm text-gray-400 mt-3">Thanks for subscribing!</p> */}
-                  <p className="text-sm text-gray-400 mt-3">No spam. You can unsubscribe at any time.</p>
-                </form>
+                <div className="flex justify-center lg:justify-start">
+                  <a className="btn text-white bg-discord hover:bg-gray-800" href="https://discord.gg/EqrUdXfbHU" target="_blank">Join Discord</a>
+                </div>
               </div>
 
             </div>


### PR DESCRIPTION
## Summary
- update home page metadata
- improve hero text and Discord link
- describe league details in feature sections
- add Discord CTA

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685090d2bdc4832dac3debd8cc688da3