### PR TITLE
Update Jest config to ignore build artifacts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  testPathIgnorePatterns: ['<rootDir>/.next/'],
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.jest.json',


### PR DESCRIPTION
## Summary
- ignore `.next` directory for Jest module paths so tests do not collide with build artifacts

## Testing
- `npm test`
- `npm run build`
- `node .next/standalone/server.js`

------
https://chatgpt.com/codex/tasks/task_e_685111daaf74832db601ba68693ec219