### PR TITLE
Add F1 25 league page

### DIFF
--- a/app/(default)/league/page.tsx
+++ b/app/(default)/league/page.tsx
@@ -1,0 +1,25 @@
+export const metadata = {
+  title: 'F1 25 League - SLF1',
+  description: 'Sunday League F1 25 racing events and schedule',
+}
+
+export default function F1League() {
+  return (
+    <section className="pt-32 pb-12 md:pt-40 md:pb-20">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <h1 className="text-5xl font-extrabold mb-6 text-red-600">Sunday League F1&nbsp;25</h1>
+        <p className="text-xl text-gray-700 mb-8">Join our weekly championship and race with drivers from around the world.</p>
+        <a href="https://discord.gg/EqrUdXfbHU" target="_blank" className="btn text-white bg-red-600 hover:bg-red-700">Join our Discord</a>
+      </div>
+      <div className="max-w-3xl mx-auto mt-16 px-4">
+        <h2 className="text-2xl font-bold mb-4">Race Schedule</h2>
+        <ul className="list-disc list-inside text-left space-y-2">
+          <li>Round 1: Bahrain - March 3</li>
+          <li>Round 2: Saudi Arabia - March 10</li>
+          <li>Round 3: Australia - March 17</li>
+          <li>Round 4: Japan - March 24</li>
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -1,22 +1,60 @@
 export const metadata = {
-  title: 'Home - SLF1',
-  description: 'Sunday League F1 25 – weekly online racing and a welcoming community',
+  title: 'SLF1 – F1 25 Racing League',
+  description: 'Join Sunday League F1 25 for weekly online races and a thriving community',
 }
 
-import Hero from '@/components/hero'
-import Features from '@/components/features'
-import FeaturesBlocks from '@/components/features-blocks'
-import Testimonials from '@/components/testimonials'
-import Newsletter from '@/components/newsletter'
+import Image from 'next/image'
+import Link from 'next/link'
+import HeroImage from '@/public/images/hero-image.png'
 
 export default function Home() {
   return (
     <>
-      <Hero />
-      <Features />
-      <FeaturesBlocks />
-      <Testimonials />
-      <Newsletter />
+      <section className="pt-32 pb-20 text-center">
+        <div className="max-w-5xl mx-auto px-4">
+          <h1 className="text-6xl font-extrabold mb-6">Sunday League F1&nbsp;25</h1>
+          <p className="text-xl text-gray-700 mb-8">Weekly online races with fair competition. Join drivers from across the globe.</p>
+          <Link href="/league" className="btn text-white bg-red-600 hover:bg-red-700">View League Details</Link>
+        </div>
+        <div className="mt-12 flex justify-center">
+          <Image src={HeroImage} alt="F1 car" className="rounded-lg w-full max-w-3xl" />
+        </div>
+      </section>
+
+      <section className="bg-gray-100 py-20">
+        <div className="max-w-5xl mx-auto px-4">
+          <h2 className="text-3xl font-bold text-center mb-8">Key Features</h2>
+          <ul className="grid md:grid-cols-3 gap-6">
+            <li className="p-6 bg-white rounded shadow">
+              <h3 className="text-xl font-semibold mb-2">Weekly Races</h3>
+              <p>50% distance with dynamic weather and realistic settings.</p>
+            </li>
+            <li className="p-6 bg-white rounded shadow">
+              <h3 className="text-xl font-semibold mb-2">Friendly Community</h3>
+              <p>Meet racers on Discord and enjoy close competition.</p>
+            </li>
+            <li className="p-6 bg-white rounded shadow">
+              <h3 className="text-xl font-semibold mb-2">Race Results</h3>
+              <p>Upload results and follow championship standings.</p>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section className="py-20">
+        <div className="max-w-3xl mx-auto text-center px-4">
+          <h2 className="text-3xl font-bold mb-4">Next Races</h2>
+          <ul className="list-disc list-inside text-left inline-block space-y-2">
+            <li>Bahrain - March 3</li>
+            <li>Saudi Arabia - March 10</li>
+            <li>Australia - March 17</li>
+            <li>Japan - March 24</li>
+          </ul>
+          <div className="mt-8">
+            <a href="https://discord.gg/EqrUdXfbHU" target="_blank" className="btn text-white bg-red-600 hover:bg-red-700">Join our Discord</a>
+          </div>
+        </div>
+      </section>
     </>
   )
 }

--- a/components/ui/header.tsx
+++ b/components/ui/header.tsx
@@ -37,6 +37,9 @@ export default function Header() {
             {/* Desktop sign in links */}
             <ul className="flex grow justify-end flex-wrap items-center space-x-6">
               <li>
+                <Link href="/league" className="text-gray-800 hover:text-gray-600 transition duration-150 ease-in-out">League</Link>
+              </li>
+              <li>
                 <Link href="/race-results" className="text-gray-800 hover:text-gray-600 transition duration-150 ease-in-out">Results</Link>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- add a dedicated `/league` page with basic schedule details
- link the new page from the main navigation
- redesign the home page with a simplified F1 racing theme

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68511b194d40832da8dabc82881d9526