### PR TITLE
Read tracks from database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 # next.js
 /.next/
 /.out/
+/out/
 
 # production
 /build

--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -6,8 +6,10 @@ export const metadata = {
 import Image from 'next/image'
 import Link from 'next/link'
 import HeroImage from '@/public/images/hero-image.png'
+import { getTracks } from '@/lib/tracks'
 
 export default function Home() {
+  const tracks = getTracks().slice(0, 4)
   return (
     <>
       <section className="pt-32 pb-20 text-center">
@@ -45,10 +47,9 @@ export default function Home() {
         <div className="max-w-3xl mx-auto text-center px-4">
           <h2 className="text-3xl font-bold mb-4">Next Races</h2>
           <ul className="list-disc list-inside text-left inline-block space-y-2">
-            <li>Bahrain - March 3</li>
-            <li>Saudi Arabia - March 10</li>
-            <li>Australia - March 17</li>
-            <li>Japan - March 24</li>
+            {tracks.map((t) => (
+              <li key={t.CircuitName}>{t.CircuitName}</li>
+            ))}
           </ul>
           <div className="mt-8">
             <a href="https://discord.gg/EqrUdXfbHU" target="_blank" className="btn text-white bg-red-600 hover:bg-red-700">Join our Discord</a>

--- a/app/api/tracks/route.ts
+++ b/app/api/tracks/route.ts
@@ -1,0 +1,8 @@
+import { getTracks } from '@/lib/tracks'
+
+export async function GET() {
+  const tracks = getTracks()
+  return new Response(JSON.stringify(tracks), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+export interface Track {
+  CircuitName: string
+}
+
+export function getTracks(): Track[] {
+  const dbPath = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
+  try {
+    const output = execFileSync(
+      'sqlite3',
+      ['-json', dbPath, 'SELECT CircuitName FROM Tracks;'],
+      { encoding: 'utf8' }
+    )
+    return JSON.parse(output) as Track[]
+  } catch (err) {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- query SQLite database for track data
- expose tracks via `/api/tracks`
- show first four tracks on home page
- ignore build output directory

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68515f01aaf8832db39a9e74f59afdb2