### PR TITLE
Add database API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ Races are held Sundays at **7 PM UK / 8 PM CET**, subject to the real-world F1
 Results and championship standings can be uploaded directly on the site.
 
 Join us on [Discord](https://discord.gg/EqrUdXfbHU) to secure your seat for the upcoming F1 25 season!
+
+## Database Endpoints
+
+The site exposes read‑only APIs that pull data from the bundled **Racing League Tools** SQLite database:
+
+- `/api/drivers` – list of all registered drivers
+- `/api/db-results` – latest 20 session results with driver, position and circuit
+
+These endpoints run SQLite queries directly on `SLF1_DB/user/databases/SLF1.db`.

--- a/app/api/db-results/route.ts
+++ b/app/api/db-results/route.ts
@@ -1,0 +1,8 @@
+import { getLatestResults } from '@/lib/sessionResults'
+
+export async function GET() {
+  const results = getLatestResults(20)
+  return new Response(JSON.stringify(results), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/app/api/drivers/route.ts
+++ b/app/api/drivers/route.ts
@@ -1,0 +1,8 @@
+import { getDrivers } from '@/lib/drivers'
+
+export async function GET() {
+  const drivers = getDrivers()
+  return new Response(JSON.stringify(drivers), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/lib/drivers.ts
+++ b/lib/drivers.ts
@@ -1,0 +1,21 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+export interface Driver {
+  Id: number
+  Name: string
+}
+
+export function getDrivers(): Driver[] {
+  const dbPath = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
+  try {
+    const output = execFileSync(
+      'sqlite3',
+      ['-json', dbPath, 'SELECT Id, Name FROM Drivers ORDER BY Name;'],
+      { encoding: 'utf8' }
+    )
+    return JSON.parse(output) as Driver[]
+  } catch (_) {
+    return []
+  }
+}

--- a/lib/sessionResults.ts
+++ b/lib/sessionResults.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from 'child_process'
+import path from 'path'
+
+export interface SessionResult {
+  driver: string
+  position: number
+  circuit: string
+  date: string
+}
+
+export function getLatestResults(limit = 10): SessionResult[] {
+  const dbPath = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
+  const query = `SELECT d.DriverName as driver, d.Position as position, t.CircuitName as circuit, s.Date as date FROM DriverSessions d JOIN SessionResults s ON d.SessionResultId = s.Id JOIN Tracks t ON s.TrackId = t.Id ORDER BY s.Date DESC LIMIT ${limit};`
+  try {
+    const output = execFileSync('sqlite3', ['-json', dbPath, query], { encoding: 'utf8' })
+    return JSON.parse(output) as SessionResult[]
+  } catch (_) {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- expose drivers and session results from the SQLite database
- document the new database API endpoints

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851696db4b4832daca6c6b08cdff1fe