### PR TITLE
Fix static asset paths

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -53,7 +53,7 @@ export default function Hero() {
             thumbWidth={768}
             thumbHeight={432}
             thumbAlt="Modal video thumbnail"
-            video="/videos/video.mp4"
+            video="videos/video.mp4"
             videoWidth={1920}
             videoHeight={1080} />
 

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,10 @@ const nextConfig = {
   reactStrictMode: true,
   // Use trailing slashes so GitHub Pages can locate index.html files
   trailingSlash: true,
+  images: {
+    // Disable dynamic image optimization for static export
+    unoptimized: true,
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- enable unoptimized images for static export
- use relative path for embedded video

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516bffa26c832d80c1f878606a268b