### PR TITLE
Add sorting controls for results page

### DIFF
--- a/app/race-results/results-client.tsx
+++ b/app/race-results/results-client.tsx
@@ -11,6 +11,7 @@ interface Result {
 
 export default function ResultsClient() {
   const [results, setResults] = useState<Result[]>([])
+  const [sort, setSort] = useState<'date' | 'race' | 'season'>('date')
 
   useEffect(() => {
     fetch('/api/db-results')
@@ -18,10 +19,26 @@ export default function ResultsClient() {
       .then(setResults)
   }, [])
 
+  const sorted = [...results].sort((a, b) => {
+    if (sort === 'race') return a.circuit.localeCompare(b.circuit)
+    if (sort === 'season') return b.date.localeCompare(a.date)
+    return b.date.localeCompare(a.date)
+  })
+
   return (
     <div>
+      <label className='mr-2 font-semibold'>Sort by:</label>
+      <select
+        value={sort}
+        onChange={e => setSort(e.target.value as 'date' | 'race' | 'season')}
+        className='border rounded p-1 mb-4'
+      >
+        <option value='date'>Date</option>
+        <option value='race'>Race</option>
+        <option value='season'>Season</option>
+      </select>
       <ul>
-        {results.map((r, i) => (
+        {sorted.map((r, i) => (
           <li key={i} className='mb-2'>{`${r.date} - ${r.circuit} - ${r.driver} - P${r.position}`}</li>
         ))}
       </ul>

--- a/lib/sessionResults.ts
+++ b/lib/sessionResults.ts
@@ -8,13 +8,32 @@ export interface SessionResult {
   date: string
 }
 
-export function getLatestResults(limit = 10): SessionResult[] {
+export function getResults(sort: 'date' | 'race' | 'season' = 'date', limit = 10): SessionResult[] {
   const dbPath = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
-  const query = `SELECT d.DriverName as driver, d.Position as position, t.CircuitName as circuit, s.Date as date FROM DriverSessions d JOIN SessionResults s ON d.SessionResultId = s.Id JOIN Tracks t ON s.TrackId = t.Id ORDER BY s.Date DESC LIMIT ${limit};`
+
+  const baseQuery =
+    'SELECT d.DriverName as driver, d.Position as position, t.CircuitName as circuit, s.Date as date ' +
+    'FROM DriverSessions d ' +
+    'JOIN SessionResults s ON d.SessionResultId = s.Id ' +
+    'JOIN Tracks t ON s.TrackId = t.Id ' +
+    'LEFT JOIN Events e ON s.EventId = e.Id'
+
+  let orderBy = 's.Date DESC'
+  if (sort === 'race') orderBy = 't.CircuitName ASC'
+  if (sort === 'season') orderBy = 'e.SeasonId DESC, s.Date DESC'
+
+  const query = `${baseQuery} ORDER BY ${orderBy} LIMIT ${limit};`
+
   try {
-    const output = execFileSync('sqlite3', ['-json', dbPath, query], { encoding: 'utf8' })
+    const output = execFileSync('sqlite3', ['-json', dbPath, query], {
+      encoding: 'utf8',
+    })
     return JSON.parse(output) as SessionResult[]
   } catch (_) {
     return []
   }
+}
+
+export function getLatestResults(limit = 10): SessionResult[] {
+  return getResults('date', limit)
 }


### PR DESCRIPTION
## Summary
- add generic result query helper that can sort by race or season
- enable sorting on Race Results page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68517423cb5c832db5baf9cae0a5a1b3