### PR TITLE
Fix track sorting

### DIFF
--- a/lib/tracks.ts
+++ b/lib/tracks.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'child_process'
 import path from 'path'
 
 export interface Track {
+  Id: number
   CircuitName: string
 }
 
@@ -10,7 +11,7 @@ export function getTracks(): Track[] {
   try {
     const output = execFileSync(
       'sqlite3',
-      ['-json', dbPath, 'SELECT CircuitName FROM Tracks;'],
+      ['-json', dbPath, 'SELECT Id, CircuitName FROM Tracks ORDER BY Id;'],
       { encoding: 'utf8' }
     )
     return JSON.parse(output) as Track[]


### PR DESCRIPTION
## Summary
- return track IDs from `getTracks`
- ensure DB query orders by track ID

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518a8a5e8c832db3db92b321d926f2