### PR TITLE
Sort race results by track name

### DIFF
--- a/app/race-results/results-client.tsx
+++ b/app/race-results/results-client.tsx
@@ -11,7 +11,6 @@ interface Result {
 
 export default function ResultsClient() {
   const [results, setResults] = useState<Result[]>([])
-  const [sort, setSort] = useState<'date' | 'race' | 'season'>('date')
 
   useEffect(() => {
     fetch('/api/db-results')
@@ -19,27 +18,14 @@ export default function ResultsClient() {
       .then(setResults)
   }, [])
 
-  const sorted = [...results].sort((a, b) => {
-    if (sort === 'race') return a.circuit.localeCompare(b.circuit)
-    if (sort === 'season') return b.date.localeCompare(a.date)
-    return b.date.localeCompare(a.date)
-  })
+  const sorted = [...results].sort((a, b) => a.circuit.localeCompare(b.circuit))
 
   return (
     <div>
-      <label className='mr-2 font-semibold'>Sort by:</label>
-      <select
-        value={sort}
-        onChange={e => setSort(e.target.value as 'date' | 'race' | 'season')}
-        className='border rounded p-1 mb-4'
-      >
-        <option value='date'>Date</option>
-        <option value='race'>Race</option>
-        <option value='season'>Season</option>
-      </select>
+      <h2 className='font-semibold mb-4'>Sorted by track name</h2>
       <ul>
         {sorted.map((r, i) => (
-          <li key={i} className='mb-2'>{`${r.date} - ${r.circuit} - ${r.driver} - P${r.position}`}</li>
+          <li key={i} className='mb-2'>{`${r.circuit} - ${r.driver} - P${r.position}`}</li>
         ))}
       </ul>
     </div>

--- a/lib/sessionResults.ts
+++ b/lib/sessionResults.ts
@@ -37,5 +37,5 @@ export function getResults(sort: 'date' | 'race' | 'season' = 'date', limit = 10
 }
 
 export function getLatestResults(limit = 10): SessionResult[] {
-  return getResults('date', limit)
+  return getResults('race', limit)
 }


### PR DESCRIPTION
## Summary
- sort latest results alphabetically by circuit
- remove sort dropdown and display entries without dates

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68518efbbd10832db6a8a6f587e03e38