### PR TITLE
Fix track dropdown filtering

### DIFF
--- a/app/race-results/results-client.tsx
+++ b/app/race-results/results-client.tsx
@@ -12,6 +12,7 @@ interface Result {
   position: number
   circuit: string
   date: string
+  trackId: number
 }
 
 export default function ResultsClient() {
@@ -32,7 +33,7 @@ export default function ResultsClient() {
   }, [])
 
   const filtered = selected
-    ? results.filter(r => r.circuit === tracks.find(t => String(t.Id) === selected)?.CircuitName)
+    ? results.filter(r => String(r.trackId) === selected)
     : results
 
   return (

--- a/lib/sessionResults.ts
+++ b/lib/sessionResults.ts
@@ -6,13 +6,15 @@ export interface SessionResult {
   position: number
   circuit: string
   date: string
+  trackId: number
 }
 
 const dbPath = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
 
 const baseQuery =
   'SELECT d.DriverName as driver, d.Position as position, ' +
-  'COALESCE(t.CircuitFullName, t.CircuitName) as circuit, s.Date as date ' +
+  'COALESCE(t.CircuitFullName, t.CircuitName) as circuit, s.Date as date, ' +
+  't.Id as trackId ' +
   'FROM DriverSessions d ' +
   'JOIN SessionResults s ON d.SessionResultId = s.Id ' +
   'JOIN Tracks t ON s.TrackId = t.Id ' +


### PR DESCRIPTION
## Summary
- include track id in SessionResult query
- update frontend filtering logic to use track id

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68519638a814832db6f4a3307642334f