### PR TITLE
Fix results limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The site exposes read‑only APIs that pull data from the bundled **Racing Leagu
 
 - `/api/drivers` – list of all registered drivers
 - `/api/tracks` – list of tracks (`?season={id}` for a specific season)
-- `/api/db-results` – latest 20 session results with driver, position and circuit
+- `/api/db-results` – latest season results (limit 100) with driver, position and circuit
 - `/api/driver-standings` – driver championship standings
 - `/api/constructor-standings` – constructor championship standings
 

--- a/app/api/db-results/route.ts
+++ b/app/api/db-results/route.ts
@@ -2,7 +2,7 @@ import { getLatestResults, getResultsBySeason } from '@/lib/sessionResults'
 import { SEASON_ID } from '@/lib/config'
 
 export async function GET() {
-  const results = getResultsBySeason(SEASON_ID, 20)
+  const results = getResultsBySeason(SEASON_ID, 100)
   return new Response(JSON.stringify(results), {
     headers: { 'Content-Type': 'application/json' },
   })


### PR DESCRIPTION
## Summary
- expand db-results API limit so filter dropdown works
- update API docs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685256a5e444832d9063ef6c34b653ce