### PR TITLE
Enable season selection for standings

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The site exposes read‑only APIs that pull data from the bundled **Racing Leagu
 - `/api/drivers` – list of all registered drivers
 - `/api/tracks` – list of tracks (`?season={id}` for a specific season)
 - `/api/db-results` – latest season results (limit 100) with driver, position and circuit
-- `/api/driver-standings` – driver championship standings
-- `/api/constructor-standings` – constructor championship standings
+- `/api/driver-standings` – driver championship standings (`?limit=&seasonId=`)
+- `/api/constructor-standings` – constructor championship standings (`?limit=&seasonId=`)
 
 These endpoints run SQLite queries directly on `SLF1_DB/user/databases/SLF1.db`.
 

--- a/app/api/constructor-standings/route.ts
+++ b/app/api/constructor-standings/route.ts
@@ -1,8 +1,16 @@
 import { getConstructorStandings } from '@/lib/standings'
+import { SEASON_ID }               from '@/lib/config'
 
-export async function GET() {
-  const standings = getConstructorStandings(10)
-  return new Response(JSON.stringify(standings), {
+export async function GET(request: Request) {
+  const params      = new URL(request.url).searchParams
+  const limitParam  = params.get('limit')
+  const seasonParam = params.get('seasonId')
+
+  const limit    = limitParam  ? Number(limitParam)  : 10
+  const seasonId = seasonParam ? Number(seasonParam) : SEASON_ID
+
+  const data = getConstructorStandings(limit, seasonId)
+  return new Response(JSON.stringify(data), {
     headers: { 'Content-Type': 'application/json' },
   })
 }

--- a/app/api/driver-standings/route.ts
+++ b/app/api/driver-standings/route.ts
@@ -1,8 +1,16 @@
 import { getDriverStandings } from '@/lib/standings'
+import { SEASON_ID }         from '@/lib/config'
 
-export async function GET() {
-  const standings = getDriverStandings(20)
-  return new Response(JSON.stringify(standings), {
+export async function GET(request: Request) {
+  const params      = new URL(request.url).searchParams
+  const limitParam  = params.get('limit')
+  const seasonParam = params.get('seasonId')
+
+  const limit    = limitParam  ? Number(limitParam)  : 20
+  const seasonId = seasonParam ? Number(seasonParam) : SEASON_ID
+
+  const data = getDriverStandings(limit, seasonId)
+  return new Response(JSON.stringify(data), {
     headers: { 'Content-Type': 'application/json' },
   })
 }

--- a/app/standings/standings-client.tsx
+++ b/app/standings/standings-client.tsx
@@ -13,20 +13,38 @@ interface ConstructorStanding {
 }
 
 export default function StandingsClient() {
-  const [drivers, setDrivers] = useState<DriverStanding[]>([])
+  const [season, setSeason]           = useState<string>('3')  // default → Season 4
+  const [drivers, setDrivers]         = useState<DriverStanding[]>([])
   const [constructors, setConstructors] = useState<ConstructorStanding[]>([])
 
   useEffect(() => {
-    fetch('/api/driver-standings')
+    const urlDrivers      = `/api/driver-standings?seasonId=${season}`
+    const urlConstructors = `/api/constructor-standings?seasonId=${season}`
+
+    fetch(urlDrivers)
       .then(res => res.json())
       .then(setDrivers)
-    fetch('/api/constructor-standings')
+      .catch(console.error)
+
+    fetch(urlConstructors)
       .then(res => res.json())
       .then(setConstructors)
-  }, [])
+      .catch(console.error)
+  }, [season])
 
   return (
     <div>
+      <label className="block font-semibold mb-2">Choose Season</label>
+      <select
+        className="form-select mb-4"
+        value={season}
+        onChange={e => setSeason(e.target.value)}
+      >
+        <option value="1">Season 2</option>
+        <option value="2">Season 3</option>
+        <option value="3">Season 4</option>
+      </select>
+
       <h2 className='font-semibold mb-2'>Driver Standings</h2>
       <ul className='mb-8'>
         {drivers.map((d, i) => (

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,2 +1,2 @@
 // Default season for API queries
-export const SEASON_ID = 2
+export const SEASON_ID = Number(process.env.SEASON_ID) || 2

--- a/lib/standings.ts
+++ b/lib/standings.ts
@@ -1,5 +1,6 @@
-import { execFileSync } from 'child_process'
+import Database from 'better-sqlite3'
 import path from 'path'
+import { SEASON_ID } from '@/lib/config'
 
 export interface DriverStanding {
   driver: string
@@ -11,26 +12,56 @@ export interface ConstructorStanding {
   points: number
 }
 
-function dbPath() {
-  return path.join(process.cwd(), 'SLF1_DB', 'user', 'databases', 'SLF1.db')
+// --- DB file selection (1–3 vs. Season 4) --------
+const DB_DIR     = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases')
+const DEFAULT_DB = path.join(DB_DIR, 'SLF1.db')    // Seasons 1–3
+const S4_DB      = path.join(DB_DIR, 'SLF1_S4.db') // Season 4 only
+
+function dbPathForSeason(seasonId: number): string {
+  return seasonId === 3 ? S4_DB : DEFAULT_DB
+}
+// --- Driver Standings -----------------------------
+export function getDriverStandings(
+  limit: number = 20,
+  seasonId: number = SEASON_ID
+): DriverStanding[] {
+  const db = new Database(dbPathForSeason(seasonId), { readonly: true })
+  const stmt = db.prepare(`
+    SELECT
+      d.DriverName    AS driver,
+      SUM(d.DriverPointsRaw) AS points
+    FROM DriverSessions d
+    JOIN SessionResults s ON d.SessionResultId = s.Id
+    JOIN Events e         ON s.EventId         = e.Id
+    WHERE e.SeasonId = ?
+    GROUP BY d.DriverName
+    ORDER BY points DESC
+    LIMIT ?
+  `)
+  const rows = stmt.all(seasonId, limit) as DriverStanding[]
+  db.close()
+  return rows
 }
 
-export function getDriverStandings(limit = 20): DriverStanding[] {
-  const query = `SELECT DriverName as driver, SUM(DriverPointsRaw) as points FROM DriverSessions GROUP BY DriverName ORDER BY points DESC LIMIT ${limit};`
-  try {
-    const output = execFileSync('sqlite3', ['-json', dbPath(), query], { encoding: 'utf8' })
-    return JSON.parse(output) as DriverStanding[]
-  } catch (_) {
-    return []
-  }
-}
-
-export function getConstructorStandings(limit = 10): ConstructorStanding[] {
-  const query = `SELECT TeamName as team, SUM(TeamPointsRaw) as points FROM DriverSessions GROUP BY TeamName ORDER BY points DESC LIMIT ${limit};`
-  try {
-    const output = execFileSync('sqlite3', ['-json', dbPath(), query], { encoding: 'utf8' })
-    return JSON.parse(output) as ConstructorStanding[]
-  } catch (_) {
-    return []
-  }
+// --- Constructor Standings ------------------------
+export function getConstructorStandings(
+  limit: number = 10,
+  seasonId: number = SEASON_ID
+): ConstructorStanding[] {
+  const db = new Database(dbPathForSeason(seasonId), { readonly: true })
+  const stmt = db.prepare(`
+    SELECT
+      d.TeamName              AS team,
+      SUM(d.TeamPointsRaw)    AS points
+    FROM DriverSessions d
+    JOIN SessionResults s ON d.SessionResultId = s.Id
+    JOIN Events e         ON s.EventId         = e.Id
+    WHERE e.SeasonId = ?
+    GROUP BY d.TeamName
+    ORDER BY points DESC
+    LIMIT ?
+  `)
+  const rows = stmt.all(seasonId, limit) as ConstructorStanding[]
+  db.close()
+  return rows
 }


### PR DESCRIPTION
## Summary
- support season-aware queries in standings library
- expose `limit` and `seasonId` params in API routes
- add season dropdown on the Standings page
- document query parameters
- read default season from `SEASON_ID` env var

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68528151e084832d88f13f0ae68dab51