### PR TITLE
Add support for Season 6 DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The site exposes read‑only APIs that pull data from the bundled **Racing Leagu
 - `/api/driver-standings` – driver championship standings (`?limit=&seasonId=`)
 - `/api/constructor-standings` – constructor championship standings (`?limit=&seasonId=`)
 
-These endpoints run SQLite queries directly on `SLF1_DB/user/databases/SLF1.db`.
+These endpoints run SQLite queries directly on the bundled databases like
+`SLF1_DB/user/databases/SLF1.db`, `SLF1_S4.db` or `SLF1_S6.db` depending on the
+selected season.
 
 ## Running with PM2
 

--- a/lib/sessionResults.ts
+++ b/lib/sessionResults.ts
@@ -4,8 +4,10 @@ import path from 'path'
 const DB_DIR     = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases')
 const DEFAULT_DB = path.join(DB_DIR, 'SLF1.db')
 const S4_DB      = path.join(DB_DIR, 'SLF1_S4.db')
+const S6_DB      = path.join(DB_DIR, 'SLF1_S6.db')
 
 function dbPathForSeason(seasonId: number): string {
+  if (seasonId === 5) return S6_DB
   return seasonId === 3 ? S4_DB : DEFAULT_DB
 }
 

--- a/lib/standings.ts
+++ b/lib/standings.ts
@@ -12,12 +12,14 @@ export interface ConstructorStanding {
   points: number
 }
 
-// --- DB file selection (1–3 vs. Season 4) --------
+// --- DB file selection ---------------------------------
 const DB_DIR     = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases')
 const DEFAULT_DB = path.join(DB_DIR, 'SLF1.db')    // Seasons 1–3
 const S4_DB      = path.join(DB_DIR, 'SLF1_S4.db') // Season 4 only
+const S6_DB      = path.join(DB_DIR, 'SLF1_S6.db') // Season 6 only
 
 function dbPathForSeason(seasonId: number): string {
+  if (seasonId === 5) return S6_DB
   return seasonId === 3 ? S4_DB : DEFAULT_DB
 }
 // --- Driver Standings -----------------------------


### PR DESCRIPTION
## Summary
- document that multiple SQLite files may be used
- handle SLF1_S6.db in `dbPathForSeason`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a71ab370832d9e4148e9c52c461b