### PR TITLE
Add dynamic season DB selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ The site exposes read‑only APIs that pull data from the bundled **Racing Leagu
 - `/api/constructor-standings` – constructor championship standings (`?limit=&seasonId=`)
 
 These endpoints run SQLite queries directly on the bundled databases like
-`SLF1_DB/user/databases/SLF1.db`, `SLF1_S4.db` or `SLF1_S6.db` depending on the
-selected season.
+`SLF1_DB/user/databases/SLF1.db` or season-specific files such as
+`SLF1_S4.db` and `SLF1_S6.db`. If a matching `SLF1_S{season}.db` is not found
+the default `SLF1.db` is used.
 
 ## Running with PM2
 

--- a/lib/standings.ts
+++ b/lib/standings.ts
@@ -1,5 +1,6 @@
 import Database from 'better-sqlite3'
 import path from 'path'
+import fs from 'fs'
 import { SEASON_ID } from '@/lib/config'
 
 export interface DriverStanding {
@@ -14,13 +15,12 @@ export interface ConstructorStanding {
 
 // --- DB file selection ---------------------------------
 const DB_DIR     = path.join(process.cwd(), 'SLF1_DB', 'user', 'databases')
-const DEFAULT_DB = path.join(DB_DIR, 'SLF1.db')    // Seasons 1–3
-const S4_DB      = path.join(DB_DIR, 'SLF1_S4.db') // Season 4 only
-const S6_DB      = path.join(DB_DIR, 'SLF1_S6.db') // Season 6 only
+const DEFAULT_DB = path.join(DB_DIR, 'SLF1.db')
 
+/** Return a season-specific DB if it exists, otherwise fallback */
 function dbPathForSeason(seasonId: number): string {
-  if (seasonId === 5) return S6_DB
-  return seasonId === 3 ? S4_DB : DEFAULT_DB
+  const custom = path.join(DB_DIR, `SLF1_S${seasonId}.db`)
+  return fs.existsSync(custom) ? custom : DEFAULT_DB
 }
 // --- Driver Standings -----------------------------
 export function getDriverStandings(


### PR DESCRIPTION
## Summary
- support season-specific databases if they exist
- clarify DB naming in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853d2d5f34c832d9bb8a351333239e9